### PR TITLE
Pass an optional report url when submitting a report

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-# git tag 0.2.3 -m "Bump version" && git push --tags origin master
+# git tag 0.2.4 -m "Bump version" && git push --tags origin master
 # python setup.py sdist
 # twine upload --skip-existing dist/*
 
@@ -7,11 +7,11 @@ from distutils.core import setup
 setup(
     name='trustar',
     packages=['trustar'],
-    version='0.2.3',
+    version='0.2.4',
     author='TruSTAR Technology, Inc.',
     author_email='support@trustar.co',
     url='https://github.com/trustar/trustar-python',
-    download_url='https://github.com/trustar/trustar-python/tarball/0.2.3',
+    download_url='https://github.com/trustar/trustar-python/tarball/0.2.4',
     description='Python SDK for the TruSTAR REST API',
     license='MIT',
     install_requires=['future',

--- a/trustar/TruStar.py
+++ b/trustar/TruStar.py
@@ -249,7 +249,7 @@ class TruStar(object):
         return json.loads(resp.content.decode('utf8'))
 
     def submit_report(self, access_token, report_body, title, external_id=None, time_began=datetime.now(),
-                      enclave=False, report_url=None, verify=True):
+                      enclave=False, external_url=None, verify=True):
         """
         Wraps supplied text as a JSON-formatted TruSTAR Incident Report and submits it to TruSTAR Station
         By default, this submits to the TruSTAR community. To submit to your enclave(s), set enclave parameter to True,
@@ -258,9 +258,9 @@ class TruStar(object):
         :param report_body: body of report
         :param title: title of report
         :param external_id: external tracking id of report, optional if user doesn't have their own tracking id that they want associated with this report
+        :param external_url: external url of report, optional and is associated with the original source of this report 
         :param time_began: time report began
         :param enclave: boolean - whether or not to submit report to user's enclaves (see 'enclave_ids' config property)
-        :param report_url: string indicating how the report was retr
         :param verify: boolean - ignore verifying the SSL certificate if you set verify to False
         """
 
@@ -276,7 +276,7 @@ class TruStar(object):
             'timeBegan': self.normalize_timestamp(time_began),
             'reportBody': report_body,
             'distributionType': distribution_type,
-            'reportUrl': report_url},
+            'externalUrl': external_url},
             'enclaveIds': self.enclaveIds}
 
         resp = requests.post(self.base + "/report", json.dumps(payload), headers=headers, timeout=60, verify=verify)

--- a/trustar/TruStar.py
+++ b/trustar/TruStar.py
@@ -249,7 +249,7 @@ class TruStar(object):
         return json.loads(resp.content.decode('utf8'))
 
     def submit_report(self, access_token, report_body, title, external_id=None, time_began=datetime.now(),
-                      enclave=False, verify=True):
+                      enclave=False, report_url=None, verify=True):
         """
         Wraps supplied text as a JSON-formatted TruSTAR Incident Report and submits it to TruSTAR Station
         By default, this submits to the TruSTAR community. To submit to your enclave(s), set enclave parameter to True,
@@ -260,6 +260,7 @@ class TruStar(object):
         :param external_id: external tracking id of report, optional if user doesn't have their own tracking id that they want associated with this report
         :param time_began: time report began
         :param enclave: boolean - whether or not to submit report to user's enclaves (see 'enclave_ids' config property)
+        :param report_url: string indicating how the report was retr
         :param verify: boolean - ignore verifying the SSL certificate if you set verify to False
         """
 
@@ -274,7 +275,8 @@ class TruStar(object):
             'externalTrackingId': external_id,
             'timeBegan': self.normalize_timestamp(time_began),
             'reportBody': report_body,
-            'distributionType': distribution_type},
+            'distributionType': distribution_type,
+            'reportUrl': report_url},
             'enclaveIds': self.enclaveIds}
 
         resp = requests.post(self.base + "/report", json.dumps(payload), headers=headers, timeout=60, verify=verify)


### PR DESCRIPTION
When submitting a report, pass an optional `report url` parameter that is either generated by the client using the Python SDK (e.g. trustash generating urls to the X-Force and Digital Shadows portals) or is left null to be populated automatically as the TruSTAR Station deeplink.

Related to this card: https://trello.com/c/Thr2fvwp/2025-design-allow-deeplinks-to-be-created-for-reports-that-can-connect-to-external-sources-digital-shadows-x-force-core-product

Related to these 2 other MRs:
https://git.trustar.co/trustar/trustar-services/merge_requests/381
https://github.com/trustar/trustar-trustash/pull/2