### PR TITLE
updated the keys in the *params* dictionary in the get_indicators_pag…

### DIFF
--- a/trustar/indicator_client.py
+++ b/trustar/indicator_client.py
@@ -146,8 +146,8 @@ class IndicatorClient(object):
             'pageSize': page_size,
             'startPage': page_number,
             'enclaveIds': enclave_ids,
-            'includedTags': included_tag_ids,
-            'excludedTags': excluded_tag_ids
+            'tagIds': included_tag_ids,
+            'excludedTagIds': excluded_tag_ids
         }
 
         resp = self._client.get("indicators", params=params)


### PR DESCRIPTION
…e() function to be *tagIds* and *excludedTagIds*, as per the documentation for this API endpoint found here:  https://docs.trustar.co/api/v13/indicators/get_indicator_list.html

This coincides with Jira tickets EN-829 and EN-791.