### PR TITLE
Added functionality for the get_indicators_metadata() method to accep…

### DIFF
--- a/trustar/indicator_client.py
+++ b/trustar/indicator_client.py
@@ -256,12 +256,12 @@ class IndicatorClient(object):
             correlation_count, last_seen, sightings, notes, tags, enclave_ids.  All other attributes of the Indicator
             objects will have Null values.  
         """
-        MAX_CHARS_IN_URL = 5000
+        MAX_CHARS_IN_URL = 4500
         
         if not indicators:
             return []
         
-        # build lists of indicators where len(types) + len(values) < 5000 characters.
+        # build lists of indicators where len(types) + len(values) < MAX_CHARS_IN_URL characters.
         list_of_indicator_lists = []
         sublist = []
         s = ''

--- a/trustar/indicator_client.py
+++ b/trustar/indicator_client.py
@@ -269,7 +269,7 @@ class IndicatorClient(object):
             sublist.append( i )
             if i.value:
                 s += i.value
-            if s.type:
+            if i.type:
                 s += i.type
             if len( s ) > MAX_CHARS_IN_URL:
                 list_of_indicator_lists.append( sublist )


### PR DESCRIPTION
…t a list of unlimited number of Indicator objects and automatically divide that list into smaller sublists that the endpoint can handle.

Without this, the method will fail if the user submits a large list of indicators to it.  I experimented a little bit, it seems to fail when the aggregate number of characters in both the indicator values and indicator types exceeds ~5500 characters, so I set a limit of 5000 characters per sub-list.  