### PR TITLE
updated submit_report() method to run the get_report_details() method…

### DIFF
--- a/trustar/report_client.py
+++ b/trustar/report_client.py
@@ -110,13 +110,46 @@ class ReportClient(object):
         Submits a report.
 
         * If ``report.is_enclave`` is ``True``, then the report will be submitted to the enclaves
-          identified by ``report.enclaves``; if that field is ``None``, then the enclave IDs registered with this
-          |TruStar| object will be used.
+          identified by ``report.enclaves``; if that field is ``None``, then the enclave IDs
+          registered with this |TruStar| object will be used.
         * If ``report.time_began`` is ``None``, then the current time will be used.
 
-        :param report: The |Report| object that was submitted, with the ``id`` field updated based
-            on values from the response.
-
+        :param report: a |Report| object, with the following attributes:
+            report.title (str): required.
+            report.body (str):  required.
+            report.is_enclave (bool):  required.  If True, then the report will only be submitted
+                to the enclaves specified in the 'enclave_ids' attribute.  If False, then the
+                report will be submitted to all of the user's private enclaves.  
+            report.enclave_ids (list of strs):  required if 'is_enclave' is True.  Ignored if
+                'is_enclave' is False / None. 
+            report.external_id (str):  optional.
+            report.external_url (str):  optional.
+            report.time_began (int): optional.  Time in milliseconds you want to assign to this
+                report.  This is the only timestamp the user can manually set.  Station will
+                set this attribute to present time if the user submits a report object with no
+                value for this attribute.
+            report.created (int):  ignored by this method.  This is an attribute that is
+                automatically set by Station to the timestamp at which the report object is
+                created in the Station platform.
+            report.updated (int):  ignored by this method.  This is an attribute that is
+                automatically set by Station to the timestamp at which the report is created
+                or updated.
+                
+        :return: The |Report| object as it was saved in Station, with the following attributes:
+            report.title:  should be same as the argument's.
+            report.body:  should be same as the argument's.
+            report.is_enclave:  should be same as the argument's.
+            report.enclave_ids:  may differ from the argument's if the argument's 'is_enclave'
+                attribute was None/False.
+            report.external_id:  should be same as the argument's.
+            report.external_url:  should be same as argument's.
+            report.time_began:  should be same as argument's.
+            report.created:  may differ from argument's, because this attribute in the the Report
+                object returned by the method will contain the value for this attribute set
+                automatically by Station.
+            report.created:  same explanation as report.created.
+                    
+            
         Example:
 
         >>> report = Report(title="Suspicious Activity",
@@ -157,9 +190,10 @@ class ReportClient(object):
         if isinstance(report_id, bytes):
             report_id = report_id.decode('utf-8')
 
-        report.id = report_id
+        # get the report as it was saved in Station.     
+        report_from_station = get_report_details( report_id )
 
-        return report
+        return report_from_station
 
     def update_report(self, report):
         """


### PR DESCRIPTION
… and return its result instead of just modifying one attribute of the report object passed as argument to the submit_report() method.  Did this because if the user intends to use the report object returned by the submit_report() method, the user is under the imporession that all of its attributes' values exactly mirror what's in Station for that report, but it's possible that Station may have different values for the 'enclave_ids', 'created', and 'updated' attributes.  Also, updated the submit_report() docstring with more description of the report objects passed as argument and returned by the method.