### PR TITLE
En 4640 phishing triage name changes

### DIFF
--- a/trustar/models/cursor_page.py
+++ b/trustar/models/cursor_page.py
@@ -12,8 +12,7 @@ import math
 class CursorPage(Page):
     """
     This class models a page of items that would be found in the body of a response from an endpoint that uses
-    pagination. Unlike the |Page| class, it uses cursor-based pagination instead of number-based pagination.
-    |CursorPage| only borrows three methods from |Page| and therefore does not inherit from it.
+    pagination. Unlike the Page class, it uses cursor-based pagination instead of number-based pagination.
 
     :ivar items: The list of items of the page; i.e. a list of indicators, reports, etc.
     :ivar cursor: A Base64-encoded string that contains information on how to retrieve the next page.

--- a/trustar/models/phishing_submission.py
+++ b/trustar/models/phishing_submission.py
@@ -12,16 +12,24 @@ class PhishingSubmission(ModelBase):
 
     :ivar submission_id: The id of the email submission
     :ivar title: The title of the email submission (email subject)
-    :ivar normalized_triage_score: The score of the email submission
+    :ivar priority_event_score: The score of the email submission
     :ivar status: The current triage status of a submission ("UNRESOLVED", "CONFIRMED", or "IGNORED")
     :ivar context: A list containing dicts which represent IOCs, sources, and scores
                     that contributed to to the triage score.
+
+    Example `context` dict:
+                 {
+                  "indicatorType": "URL",
+                  "indicatorValue":"clickhere.com",
+                  "sourceKey":"crowdstrike_indicator",
+                  "normalizedIndicatorScore":1
+                 }
     """
 
     def __init__(self,
                  submission_id=None,
                  title=None,
-                 normalized_triage_score=None,
+                 priority_event_score=None,
                  status=None,
                  context=None):
         """
@@ -30,7 +38,7 @@ class PhishingSubmission(ModelBase):
         """
         self.submission_id = submission_id
         self.title = title
-        self.normalized_triage_score = normalized_triage_score
+        self.priority_event_score = priority_event_score
         self.status = status
         self.context = context
 
@@ -45,7 +53,7 @@ class PhishingSubmission(ModelBase):
 
         return PhishingSubmission(submission_id=phishing_submission.get('submissionId'),
                                   title=phishing_submission.get('title'),
-                                  normalized_triage_score=phishing_submission.get('normalizedTriageScore'),
+                                  priority_event_score=phishing_submission.get('priorityEventScore'),
                                   status=phishing_submission.get('status'),
                                   context=phishing_submission.get('context'))
 
@@ -63,7 +71,7 @@ class PhishingSubmission(ModelBase):
         return {
             'submissionId': self.submission_id,
             'title': self.title,
-            'normalizedTriageScore': self.normalized_triage_score,
+            'priorityEventScore': self.priority_event_score,
             'status': self.status,
             'context': self.context,
         }
@@ -77,21 +85,24 @@ class PhishingIndicator(ModelBase):
     :ivar value: The value of an extracted entity (e.g. www.badsite.com, etc.)
     :ivar source_key: A string that is associated with the closed source providing context
                        (e.g. 'virustotal', 'crowdstrike_indicator')
-    :ivar normalized_source_score: The normalized score associated with a context entity
+    :ivar normalized_indicator_score: The normalized score associated with a context entity
+    :ivar original_indicator_score: A score given to the indicator by its original source
     """
 
     def __init__(self,
                  indicator_type=None,
                  value=None,
                  source_key=None,
-                 normalized_source_score=None):
+                 normalized_indicator_score=None,
+                 original_indicator_score=None):
         """
         Constructs a PhishingIndicator object.
         """
         self.indicator_type = indicator_type
         self.value = value
         self.source_key = source_key
-        self.normalized_source_score = normalized_source_score
+        self.normalized_indicator_score = normalized_indicator_score
+        self.original_indicator_score = original_indicator_score
 
     @classmethod
     def from_dict(cls, phishing_indicator):
@@ -104,7 +115,8 @@ class PhishingIndicator(ModelBase):
         return PhishingIndicator(indicator_type=phishing_indicator.get('indicatorType'),
                                  value=phishing_indicator.get('value'),
                                  source_key=phishing_indicator.get('sourceKey'),
-                                 normalized_source_score=phishing_indicator.get('normalizedSourceScore'))
+                                 normalized_indicator_score=phishing_indicator.get('normalizedIndicatorScore'),
+                                 original_indicator_score=phishing_indicator.get('originalIndicatorScore'))
 
     def to_dict(self, remove_nones=False):
         """
@@ -121,5 +133,6 @@ class PhishingIndicator(ModelBase):
             'indicatorType': self.indicator_type,
             'value': self.value,
             'sourceKey': self.source_key,
-            'normalizedSourceScore': self.normalized_source_score,
+            'normalizedIndicatorScore': self.normalized_indicator_score,
+            'originalIndicatorScore': self.original_indicator_score
         }

--- a/trustar/phishing_triage_client.py
+++ b/trustar/phishing_triage_client.py
@@ -28,14 +28,14 @@ class PhishingTriageClient(object):
         """
         return {k: v for k, v in d.items() if v is not None}
 
-    def get_phishing_submissions(self, from_time=None, to_time=None, normalized_triage_score=None,
+    def get_phishing_submissions(self, from_time=None, to_time=None, priority_event_score=None,
                                  enclave_ids=None, status=None, cursor=None):
         """
         Fetches all phishing submissions that fit a given criteria.
 
         :param int from_time: Start of time window in milliseconds since epoch (defaults to 7 days ago)
         :param int to_time: End of time window in milliseconds since epoch (defaults to current time)
-        :param list(int) normalized_triage_score: List of desired scores of phishing submission on a scale of 0-3
+        :param list(int) priority_event_score: List of desired scores of phishing submission on a scale of 0-3
                                              (default: [3]).
         :param list(string) enclave_ids: List of enclave ids to pull submissions from.
                                          (defaults to all of a user's enclaves).
@@ -48,7 +48,7 @@ class PhishingTriageClient(object):
         phishing_submissions_page_generator = self._get_phishing_submissions_page_generator(
             from_time=from_time,
             to_time=to_time,
-            normalized_triage_score=normalized_triage_score,
+            priority_event_score=priority_event_score,
             enclave_ids=enclave_ids,
             status=status,
             cursor=cursor
@@ -56,14 +56,14 @@ class PhishingTriageClient(object):
 
         return CursorPage.get_generator(page_generator=phishing_submissions_page_generator)
 
-    def _get_phishing_submissions_page_generator(self, from_time=None, to_time=None, normalized_triage_score=None,
+    def _get_phishing_submissions_page_generator(self, from_time=None, to_time=None, priority_event_score=None,
                                                  enclave_ids=None, status=None, cursor=None):
         """
         Creates a generator from the |get_indicators_page| method that returns each successive page.
 
         :param int from_time: Start of time window in milliseconds since epoch (defaults to 7 days ago).
         :param int to_time: End of time window in milliseconds since epoch (defaults to current time).
-        :param list(int) normalized_triage_score: List of desired scores of phishing submission on a scale of 0-3
+        :param list(int) priority_event_score: List of desired scores of phishing submission on a scale of 0-3
                                                   (default: [3]).
         :param list(string) enclave_ids: A list of enclave IDs to filter by. (defaults to all of a user's enclaves)
         :param list(string) status: List of statuses to filter submissions by. Options are 'UNRESOLVED', 'CONFIRMED',
@@ -76,21 +76,21 @@ class PhishingTriageClient(object):
             self.get_phishing_submissions_page,
             from_time=from_time,
             to_time=to_time,
-            normalized_triage_score=normalized_triage_score,
+            priority_event_score=priority_event_score,
             enclave_ids=enclave_ids,
             status=status,
         )
 
         return CursorPage.get_cursor_based_page_generator(get_page, cursor=cursor)
 
-    def get_phishing_submissions_page(self, from_time=None, to_time=None, normalized_triage_score=None,
+    def get_phishing_submissions_page(self, from_time=None, to_time=None, priority_event_score=None,
                                       enclave_ids=None, status=None, cursor=None):
         """
         Get a page of phishing submissions that match the given criteria.
 
         :param int from_time: Start of time window in milliseconds since epoch (defaults to 7 days ago).
         :param int to_time: End of time window in milliseconds since epoch (defaults to current time).
-        :param list(int) normalized_triage_score: List of desired scores of phishing submission on a scale of 0-3
+        :param list(int) priority_event_score: List of desired scores of phishing submission on a scale of 0-3
                                              (default: [3]).
         :param list(string) enclave_ids: A list of enclave IDs to filter by. (defaults to all of a user's enclaves)
         :param list(string) status: List of statuses to filter submissions by. Options are 'UNRESOLVED', 'CONFIRMED',
@@ -102,7 +102,7 @@ class PhishingTriageClient(object):
         data = self.remove_nones({
             'from': from_time,
             'to': to_time,
-            'normalizedTriageScore': normalized_triage_score,
+            'priorityEventScore': priority_event_score,
             'enclaveIds': enclave_ids,
             'status': status,
             'cursor': cursor
@@ -129,16 +129,16 @@ class PhishingTriageClient(object):
         return self._client.post("triage/submissions/{submission_id}/status"
                                  .format(submission_id=submission_id), params=params)
 
-    def get_phishing_indicators(self, from_time=None, to_time=None, normalized_source_score=None,
-                                normalized_triage_score=None, status=None, enclave_ids=None, cursor=None):
+    def get_phishing_indicators(self, from_time=None, to_time=None, normalized_indicator_score=None,
+                                priority_event_score=None, status=None, enclave_ids=None, cursor=None):
         """
         Get a page of phishing indicators that match the given criteria.
 
         :param int from_time: Start of time window in milliseconds since epoch (defaults to 7 days ago).
         :param int to_time: End of time window in milliseconds since epoch (defaults to current time).
-        :param list(int) normalized_source_score: List of desired scores of intel sources on a scale of 0-3
+        :param list(int) normalized_indicator_score: List of desired scores of intel sources on a scale of 0-3
                                                   (default: [3]).
-        :param list(int) normalized_triage_score: List of desired scores of phishing indicators on a scale of 0-3
+        :param list(int) priority_event_score: List of desired scores of phishing indicators on a scale of 0-3
                                                   (default: [3]).
         :param list(string) enclave_ids: A list of enclave IDs to filter by. (defaults to all of a user's enclaves)
         :param list(string) status: List of statuses to filter indicators by. Options are 'UNRESOLVED', 'CONFIRMED',
@@ -150,8 +150,8 @@ class PhishingTriageClient(object):
         phishing_indicators_page_generator = self._get_phishing_indicators_page_generator(
             from_time=from_time,
             to_time=to_time,
-            normalized_source_score=normalized_source_score,
-            normalized_triage_score=normalized_triage_score,
+            normalized_indicator_score=normalized_indicator_score,
+            priority_event_score=priority_event_score,
             enclave_ids=enclave_ids,
             status=status,
             cursor=cursor
@@ -159,17 +159,17 @@ class PhishingTriageClient(object):
 
         return CursorPage.get_generator(page_generator=phishing_indicators_page_generator)
 
-    def _get_phishing_indicators_page_generator(self, from_time=None, to_time=None, normalized_source_score=None,
-                                                normalized_triage_score=None, enclave_ids=None, status=None,
+    def _get_phishing_indicators_page_generator(self, from_time=None, to_time=None, normalized_indicator_score=None,
+                                                priority_event_score=None, enclave_ids=None, status=None,
                                                 cursor=None):
         """
         Creates a generator from the |get_indicators_page| method that returns each successive page.
 
         :param int from_time: Start of time window in milliseconds since epoch (defaults to 7 days ago).
         :param int to_time: End of time window in milliseconds since epoch (defaults to current time).
-        :param list(int) normalized_source_score: List of desired scores of intel sources on a scale of 0-3
+        :param list(int) normalized_indicator_score: List of desired scores of intel sources on a scale of 0-3
                                                   (default: [3]).
-        :param list(int) normalized_triage_score: List of desired scores of phishing indicators on a scale of 0-3
+        :param list(int) priority_event_score: List of desired scores of phishing indicators on a scale of 0-3
                                                   (default: [3]).
         :param list(string) enclave_ids: A list of enclave IDs to filter by. (defaults to all of a user's enclaves)
         :param list(string) status: List of statuses to filter indicators by. Options are 'UNRESOLVED', 'CONFIRMED',
@@ -182,24 +182,24 @@ class PhishingTriageClient(object):
             self.get_phishing_indicators_page,
             from_time=from_time,
             to_time=to_time,
-            normalized_source_score=normalized_source_score,
-            normalized_triage_score=normalized_triage_score,
+            normalized_indicator_score=normalized_indicator_score,
+            priority_event_score=priority_event_score,
             enclave_ids=enclave_ids,
             status=status,
         )
 
         return CursorPage.get_cursor_based_page_generator(get_page, cursor=cursor)
 
-    def get_phishing_indicators_page(self, from_time=None, to_time=None, normalized_source_score=None,
-                                     normalized_triage_score=None, enclave_ids=None, status=None, cursor=None):
+    def get_phishing_indicators_page(self, from_time=None, to_time=None, normalized_indicator_score=None,
+                                     priority_event_score=None, enclave_ids=None, status=None, cursor=None):
         """
         Get a page of phishing indicators that match the given criteria.
 
         :param int from_time: Start of time window in milliseconds since epoch (defaults to 7 days ago).
         :param int to_time: End of time window in milliseconds since epoch (defaults to current time).
-        :param list(int) normalized_source_score: List of desired scores of intel sources on a scale of 0-3
+        :param list(int) normalized_indicator_score: List of desired scores of intel sources on a scale of 0-3
                                                   (default: [3]).
-        :param list(int) normalized_triage_score: List of desired scores of phishing indicators on a scale of 0-3
+        :param list(int) priority_event_score: List of desired scores of phishing indicators on a scale of 0-3
                                              (default: [3]).
         :param list(string) enclave_ids: A list of enclave IDs to filter by.
         :param list(string) status: List of statuses to filter indicators by. Options are 'UNRESOLVED', 'CONFIRMED',
@@ -211,8 +211,8 @@ class PhishingTriageClient(object):
         data = self.remove_nones({
             'from': from_time,
             'to': to_time,
-            'normalizedSourceScore': normalized_source_score,
-            'normalizedTriageScore': normalized_triage_score,
+            'normalizedIndicatorScore': normalized_indicator_score,
+            'priorityEventScore': priority_event_score,
             'enclaveIds': enclave_ids,
             'status': status,
             'cursor': cursor


### PR DESCRIPTION
I updated the field names to reflect the changes to the API. The one thing I want to note is that I store the entire `context` list returned by `/triage/submissions` as a single attribute in a `PhishingSubmission` object. This means that no changes were needed to reflect the addition of `originalIndicatorScore` and `normalizedIndicatorScore` in `context`. Originally I was bootstrapping `context` with the `PhishingIndicator` class because I thought that the field names were the same, but this had caused the SDK to break because the `value` field in context is called `indicatorValue` in  a phishing indicator response object. If we need the `context` object to be documented in the code, I could create a separate `Context` mix-in class, but I'm not sure if this is necessary, or if it's over-engineering the problem since it would be almost identical to `PhishingIndicator`. Let me know!