### PR TITLE
External id encoder

### DIFF
--- a/trustar/utilities/external_id_encoder.py
+++ b/trustar/utilities/external_id_encoder.py
@@ -1,0 +1,67 @@
+# encoding = utf-8
+
+""" An object that encodes TruSTAR external IDs. """
+
+import base64
+from logging import getLogger
+import uuid
+
+from typing import TYPE_CHECKING
+if TYPE_CHECKING:
+    from logging import Logger
+
+logger = getLogger(__name__)                                    # type: Logger
+
+__ARBITRARY_SEED = 'f541adc0-f8b4-42a3-a1d9-fbcbfb2820a5'
+ENCLAVE_UUID_NAMESPACE = uuid.UUID(__ARBITRARY_SEED)
+
+class ExternalIdEncoder:
+    """ Encodes eternal IDs for TruSTAR reports.
+    External IDs need to:
+    - calculate to the same thing every time, given the same inputs.
+    - be url-encodeable. (some endpoints use them in query-string-params). """
+
+    def __init__(self, exception_if_reversible_fails=True         # type: bool
+                 ):
+        self.exc_if_rev_fail = exception_if_reversible_fails      # type: bool
+
+    @staticmethod
+    def irreversible(enclave_id, external_id):       # type: (str, str) -> str
+        """ Uses enclave ID and desired external ID to produce an
+        external ID that will always work with Station. """
+
+        try:
+            namespace_uuid = uuid.UUID(enclave_id)
+        except ValueError:
+            # if the enclave_id was not a valid UUID, hash it to create one.
+            # some staging enclave_ids are not valid UUIDs.
+            namespace_uuid = uuid.uuid5(ENCLAVE_UUID_NAMESPACE,
+                                        enclave_id)
+
+        return str(uuid.uuid5(namespace_uuid, external_id))
+
+    def reversible(self, enclave_id, external_id):   # type: (str, str) -> str
+        """ Makes a reversible external ID. """
+        s = enclave_id + '|' + external_id                       # type: str
+        b = s.encode('utf-8')                                    # type: bytes
+        encoded = base64.b64encode(b)                            # type: bytes
+        stringified_b64_encoding = encoded.decode('utf-8')       # type: str
+        if self.reverse(stringified_b64_encoding) != s:
+            msg = ("External ID encoder's 'reversible' method produced an  "
+                   "external ID that its 'reverse' method did not "
+                   "successfully reverse. String: '{}'.  Stringified "
+                   "encoding:  '{}'."
+                   .format(s, stringified_b64_encoding))
+            logger.error(msg)
+            if self.exc_if_rev_fail:
+                raise Exception(msg)
+
+        return stringified_b64_encoding
+
+    @staticmethod
+    def reverse(stringified_b64_encoding):                # type: (str) -> str
+        """ Reverses an external ID created by the 'reversible' method. """
+        b64_encoding = stringified_b64_encoding.encode('utf-8')  # type: bytes
+        b = base64.b64decode(b64_encoding)                       # type: bytes
+        s = b.decode('utf-8')
+        return s

--- a/trustar/utilities/external_id_encoder.py
+++ b/trustar/utilities/external_id_encoder.py
@@ -41,7 +41,14 @@ class ExternalIdEncoder:
         return str(uuid.uuid5(namespace_uuid, external_id))
 
     def reversible(self, enclave_id, external_id):   # type: (str, str) -> str
-        """ Makes a reversible external ID. """
+        """ Makes a reversible external ID.  Ensures that all
+        characters in the resulting external ID can be present in a URL.
+        :param enclave_id: str containing the enclave ID the report
+        will be submitted to.
+        :param external_id: str containing the external ID you'd like
+        to give the report. Often this is an IOC value.
+        :return: str containing base-64 encoding of the enclave ID +
+        external ID. """
         s = enclave_id + '|' + external_id                       # type: str
         b = s.encode('utf-8')                                    # type: bytes
         encoded = base64.b64encode(b)                            # type: bytes


### PR DESCRIPTION
What:  A class that can be used to create external IDs for reports.  

Why:  
1) Character-control.  External IDs are used in URL parameters in calls to some of TruSTAR's API endpoints, so all characters in them must be valid in URLs.  
2) An external ID can only refer to a single report in a TruSTAR customer company account's scope (all enclaves it has access to).  For indicator-query stashes and TAXII stashes we like to be able to reference a report by the IOC it's about.  However, if the customer has access to multiple indicator-query stashes,  it's possible that if they use only the IOC value as the external ID, multiple stashes could fight over the use of that single external ID.  This object provides an easily repeatable way of dealing with that.  
3) This is a problem that has to be solved both in TruStash and in custom code that customers write, and logic of this nature has been written differently in several integrations.  It's time to standardize on one piece of code that solves this problem. 

How:
This class provides one method that calculates a UUID5 to use as the external ID and another that calculates a base-64 encoding of an external ID and enclave ID.  
UUID5's are deterministic, but not reversible.  
base-64 encodings are deterministic, and also reversible.  Their drawback is that the possibility exists that it's possible that they could be so long that they exceed the # characters allowed in a report's externalID.  This is unlikely for most uses, so it's still handy to have the ability to create an encoded external ID that can be decoded if desired. 