### PR TITLE
PL-41 Adding the bulk indicator metadata export to the sdk

### DIFF
--- a/trustar/examples/indicator_bulk_export.py
+++ b/trustar/examples/indicator_bulk_export.py
@@ -22,13 +22,15 @@ status = ts.get_indicator_metadata_export_status(guid)
 logger.info("Status = %s" % status)
 
 # Loop until the status is either ERROR or COMPLETE
-while status != "ERROR" and status != "COMPLETE":
+while status != "ERROR" and status != "CANCELED" and status != "COMPLETE":
     sleep(10)
     status = ts.get_indicator_metadata_export_status(guid)
     logger.info("Status = %s" % status)
 
 if status == "ERROR":
     logger.error("Job failed")
+elif status == "CANCELED":
+    logger.error("Job was canceled")
 else:
     logger.info("Saving export to %s.csv" % guid)
     ts.download_indicator_metadata_export(guid, "%s.csv" % guid)

--- a/trustar/examples/indicator_bulk_export.py
+++ b/trustar/examples/indicator_bulk_export.py
@@ -1,0 +1,36 @@
+"""
+This script will initiate a bulk export of all indicator metadata for indicators
+that contain google.com and save them to a local file.  In order to work
+correctly, the api_endpoint in your config must be for 2.0 (<host>/api/2.0)
+"""
+
+from time import sleep
+
+from trustar import datetime_to_millis, log, TruStar
+
+# initialize SDK
+ts = TruStar()
+
+# initialize logger
+logger = log.get_logger(__name__)
+
+guid = ts.initiate_indicator_metadata_export('google.com')
+logger.info("Job initiated - %s" % guid)
+
+sleep(10)
+status = ts.get_indicator_metadata_export_status(guid)
+logger.info("Status = %s" % status)
+
+# Loop until the status is either ERROR or COMPLETE
+while status != "ERROR" and status != "COMPLETE":
+    sleep(10)
+    status = ts.get_indicator_metadata_export_status(guid)
+    logger.info("Status = %s" % status)
+
+if status == "ERROR":
+    logger.error("Job failed")
+else:
+    logger.info("Saving export to %s.csv" % guid)
+    ts.download_indicator_metadata_export(guid, "%s.csv" % guid)
+    logger.info("Export complete!")
+

--- a/trustar/examples/indicator_bulk_export.py
+++ b/trustar/examples/indicator_bulk_export.py
@@ -5,7 +5,7 @@ that contain google.com and save them to a local file.
 
 from time import sleep
 
-from trustar import datetime_to_millis, log, TruStar
+from trustar import log, TruStar
 
 # initialize SDK
 ts = TruStar()
@@ -21,7 +21,7 @@ status = ts.get_indicator_metadata_export_status(guid)
 logger.info("Status = %s" % status)
 
 # Loop until the status is either ERROR or COMPLETE
-while status != "ERROR" and status != "CANCELED" and status != "COMPLETE":
+while status not in ("ERROR", "CANCELED", "COMPLETE"):
     sleep(10)
     status = ts.get_indicator_metadata_export_status(guid)
     logger.info("Status = %s" % status)
@@ -34,4 +34,3 @@ else:
     logger.info("Saving export to %s.csv" % guid)
     ts.download_indicator_metadata_export(guid, "%s.csv" % guid)
     logger.info("Export complete!")
-

--- a/trustar/examples/indicator_bulk_export.py
+++ b/trustar/examples/indicator_bulk_export.py
@@ -1,7 +1,6 @@
 """
 This script will initiate a bulk export of all indicator metadata for indicators
-that contain google.com and save them to a local file.  In order to work
-correctly, the api_endpoint in your config must be for 2.0 (<host>/api/2.0)
+that contain google.com and save them to a local file.
 """
 
 from time import sleep

--- a/trustar/indicator_client.py
+++ b/trustar/indicator_client.py
@@ -597,9 +597,7 @@ class IndicatorClient(object):
                                            to_time=None,
                                            indicator_types=None,
                                            tags=None,
-                                           excluded_tags=None,
-                                           page_size=None,
-                                           page_number=None):
+                                           excluded_tags=None):
         """
         Initiate a bulk export of indicator metadata
 

--- a/trustar/indicator_client.py
+++ b/trustar/indicator_client.py
@@ -657,5 +657,3 @@ class IndicatorClient(object):
             with open(filename, 'wb') as f:
                 for chunk in r.iter_content(chunk_size=8192):
                     f.write(chunk)
-
-        return None

--- a/trustar/indicator_client.py
+++ b/trustar/indicator_client.py
@@ -624,9 +624,7 @@ class IndicatorClient(object):
             'to': to_time,
             'entityTypes': indicator_types,
             'tags': tags,
-            'excludedTags': excluded_tags,
-            'pageSize': page_size,
-            'pageNumber': page_number
+            'excludedTags': excluded_tags
         }
 
         resp = self._client.post("indicators/metadata/bulk-export", params=params, data=json.dumps(body))


### PR DESCRIPTION
What? - I'm adding the API commands to initiate an indicator metadata bulk export, monitor its status, and download the export file that is generated
Why? - Peter Wrenn has a customer than needs to export a large number of indicators from our system and none of the previous methods were very good at that
How? - I followed the existing patterns to create a POST to initiate the bulk async job, and GETs for pulling down the status and the completed export file.  I also added an example script that shows how to run it.